### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/pubsubjobs/driver.go
+++ b/pubsubjobs/driver.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -23,7 +22,9 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -67,7 +68,7 @@ type Driver struct {
 
 	// if a user invokes several resume operations
 	listeners atomic.Uint32
-	stopped   uint64
+	stopped   atomic.Uint64
 }
 
 // FromConfig initializes google_pub_sub_driver_ pipeline
@@ -283,7 +284,7 @@ func (d *Driver) State(ctx context.Context) (*jobs.State, error) {
 func (d *Driver) Pause(ctx context.Context, p string) error {
 	start := time.Now().UTC()
 
-	_, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(tracerName).Start(ctx, "google_pub_sub_resume")
+	_, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(tracerName).Start(ctx, "google_pub_sub_pause")
 	defer span.End()
 
 	// load atomic value
@@ -340,7 +341,7 @@ func (d *Driver) Resume(ctx context.Context, p string) error {
 
 func (d *Driver) Stop(ctx context.Context) error {
 	start := time.Now().UTC()
-	atomic.StoreUint64(&d.stopped, 1)
+	d.stopped.Store(1)
 
 	_, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(tracerName).Start(ctx, "google_pub_sub_stop")
 	defer span.End()
@@ -371,12 +372,12 @@ func (d *Driver) manageSubscriptions() error {
 
 	topic, err := d.gclient.TopicAdminClient.CreateTopic(ctx, topicpb)
 	if err != nil {
-		if !strings.Contains(err.Error(), "Topic already exists") {
+		if status.Code(err) != codes.AlreadyExists {
 			return err
 		}
 
 		// topic would be nil if it already exists
-		topic, err = d.gclient.TopicAdminClient.GetTopic(ctx, &pubsubpb.GetTopicRequest{Topic: d.topicStr})
+		topic, err = d.gclient.TopicAdminClient.GetTopic(ctx, &pubsubpb.GetTopicRequest{Topic: topicpb.Name})
 		if err != nil {
 			return err
 		}
@@ -392,7 +393,7 @@ func (d *Driver) manageSubscriptions() error {
 		}
 		dltopic, err = d.gclient.TopicAdminClient.CreateTopic(ctx, dltopicpb)
 		if err != nil {
-			if !strings.Contains(err.Error(), "already exists") {
+			if status.Code(err) != codes.AlreadyExists {
 				return err
 			}
 
@@ -414,7 +415,7 @@ func (d *Driver) manageSubscriptions() error {
 		DeadLetterPolicy:   initOrNil(dltopic, d.maxDeliveryAttempts),
 	})
 	if err != nil {
-		if !strings.Contains(err.Error(), "already exists") {
+		if status.Code(err) != codes.AlreadyExists {
 			return err
 		}
 	}
@@ -449,7 +450,7 @@ func (d *Driver) handlePush(ctx context.Context, job *Item) error {
 			jobs.RRDelay:    strconv.Itoa(int(job.Options.Delay)),
 			jobs.RRHeaders:  string(data),
 			jobs.RRPriority: strconv.Itoa(int(job.Options.Priority)),
-			jobs.RRAutoAck:  btos(job.Options.AutoAck),
+			jobs.RRAutoAck:  strconv.FormatBool(job.Options.AutoAck),
 		},
 		PublishTime: time.Now().UTC(),
 	})

--- a/pubsubjobs/item.go
+++ b/pubsubjobs/item.go
@@ -46,7 +46,7 @@ type Options struct {
 	// Private ================
 	requeueFn func(ctx context.Context, job *Item) error
 	message   *pubsub.Message
-	stopped   *uint64
+	stopped   *atomic.Uint64
 }
 
 // DelayDuration returns delay duration in the form of time.Duration.
@@ -76,35 +76,26 @@ func (i *Item) Headers() map[string][]string {
 }
 
 // Context packs job context (job, id) into binary payload.
-// Not used in the amqp, amqp.Table used instead
 func (i *Item) Context() ([]byte, error) {
-	ctx, err := json.Marshal(
-		struct {
-			ID       string              `json:"id"`
-			Job      string              `json:"job"`
-			Driver   string              `json:"driver"`
-			Queue    string              `json:"queue"`
-			Headers  map[string][]string `json:"headers"`
-			Pipeline string              `json:"pipeline"`
-		}{
-			ID:       i.Ident,
-			Job:      i.Job,
-			Driver:   pluginName,
-			Headers:  i.headers,
-			Queue:    i.Options.Queue,
-			Pipeline: i.Options.Pipeline,
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return ctx, nil
+	return json.Marshal(struct {
+		ID       string              `json:"id"`
+		Job      string              `json:"job"`
+		Driver   string              `json:"driver"`
+		Queue    string              `json:"queue"`
+		Headers  map[string][]string `json:"headers"`
+		Pipeline string              `json:"pipeline"`
+	}{
+		ID:       i.Ident,
+		Job:      i.Job,
+		Driver:   pluginName,
+		Headers:  i.headers,
+		Queue:    i.Options.Queue,
+		Pipeline: i.Options.Pipeline,
+	})
 }
 
 func (i *Item) Ack() error {
-	if atomic.LoadUint64(i.Options.stopped) == 1 {
+	if i.Options.stopped.Load() == 1 {
 		return errors.Str("failed to acknowledge the JOB, the pipeline is probably stopped")
 	}
 	// return in case of auto-ack
@@ -117,7 +108,7 @@ func (i *Item) Ack() error {
 }
 
 func (i *Item) Nack() error {
-	if atomic.LoadUint64(i.Options.stopped) == 1 {
+	if i.Options.stopped.Load() == 1 {
 		return errors.Str("failed to acknowledge the JOB, the pipeline is probably stopped")
 	}
 
@@ -132,7 +123,7 @@ func (i *Item) Nack() error {
 }
 
 func (i *Item) NackWithOptions(requeue bool, _ int) error {
-	if atomic.LoadUint64(i.Options.stopped) == 1 {
+	if i.Options.stopped.Load() == 1 {
 		return errors.Str("failed to acknowledge the JOB, the pipeline is probably stopped")
 	}
 
@@ -170,7 +161,7 @@ func (i *Item) NackWithOptions(requeue bool, _ int) error {
 
 // Requeue is a non-native method, it's used to requeue the message back to the queue but with new headers
 func (i *Item) Requeue(headers map[string][]string, _ int) error {
-	if atomic.LoadUint64(i.Options.stopped) == 1 {
+	if i.Options.stopped.Load() == 1 {
 		return errors.Str("failed to acknowledge the JOB, the pipeline is probably stopped")
 	}
 
@@ -249,7 +240,7 @@ func (d *Driver) unpack(message *pubsub.Message) *Item {
 
 	var autoAck bool
 	if val, ok := attributes[jobs.RRAutoAck]; ok {
-		autoAck = stob(val)
+		autoAck, _ = strconv.ParseBool(val)
 	}
 
 	var dl int
@@ -286,22 +277,6 @@ func (d *Driver) unpack(message *pubsub.Message) *Item {
 			requeueFn: d.handlePush,
 		},
 	}
-}
-
-func btos(b bool) string {
-	if b {
-		return "true"
-	}
-
-	return "false"
-}
-
-func stob(s string) bool {
-	if s != "" {
-		return s == "true"
-	}
-
-	return false
 }
 
 func handleResult(err error, ar pubsub.AcknowledgeStatus) error {

--- a/pubsubjobs/listener.go
+++ b/pubsubjobs/listener.go
@@ -3,11 +3,11 @@ package pubsubjobs
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 
 	"cloud.google.com/go/pubsub/v2"
 	"github.com/roadrunner-server/events"
 	"go.opentelemetry.io/otel/propagation"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -55,8 +55,7 @@ func (d *Driver) listen() {
 				d.listeners.Store(0)
 				return
 			}
-			st := status.Convert(err)
-			if st != nil && st.Message() == "grpc: the client connection is closing" {
+			if status.Code(err) == codes.Canceled {
 				// reduce the number of listeners
 				if d.listeners.Load() > 0 {
 					d.listeners.Add(^uint32(0))
@@ -68,7 +67,7 @@ func (d *Driver) listen() {
 
 			d.listeners.Store(0)
 			// the pipeline was stopped
-			if atomic.LoadUint64(&d.stopped) == 1 {
+			if d.stopped.Load() == 1 {
 				return
 			}
 


### PR DESCRIPTION
## Applied fixes

**Bug fixes (R):**
- Fix `GetTopicRequest` using bare topic name (`d.topicStr`) instead of full resource path (`projects/{project}/topics/{name}`) — was returning NOT_FOUND on existing topics
- Replace fragile `strings.Contains(err.Error(), "already exists")` with `status.Code(err) == codes.AlreadyExists` in all three `CreateTopic`/`CreateSubscription` error checks
- Replace `st.Message() == "grpc: the client connection is closing"` string match with `status.Code(err) == codes.Canceled` in listener

**Modernization (M):**
- `stopped uint64` field + `sync/atomic` package-level funcs → `atomic.Uint64` value field (driver, item, listener)
- `Options.stopped *uint64` → `*atomic.Uint64`; call sites use `.Load()` / `.Store()`
- `btos`/`stob` helpers removed → `strconv.FormatBool` / `strconv.ParseBool`
- `Context()` two-step marshal+return → single `return json.Marshal(...)`

**Simplifications (S):**
- Fix Pause span name copy-paste: `"google_pub_sub_resume"` → `"google_pub_sub_pause"`

